### PR TITLE
Remove unnecessary dep on 5.16

### DIFF
--- a/lib/Mojo/UserAgent/Mockable/Proxy.pm
+++ b/lib/Mojo/UserAgent/Mockable/Proxy.pm
@@ -1,4 +1,4 @@
-use 5.016;
+use 5.014;
 
 # ABSTRACT: Proxy class for Mojo::UserAgent::Mockable that will not set any proxy.
 

--- a/t/record_playback_proxy.t
+++ b/t/record_playback_proxy.t
@@ -1,4 +1,4 @@
-use 5.016;
+use 5.014;
 
 # Test MUA::Mockable behavior with CONNECT proxies. Heavily based on 
 # https://metacpan.org/source/SRI/Mojolicious-7.26/t/mojo/websocket_proxy_tls.t


### PR DESCRIPTION
The proxy class and tests depend on 5.16 but does not use or need any features from 5.16. Would be nice if this module could be used on perl 5.14 as well.