### PR TITLE
18: Fix Failing Test

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 {{$NEXT}}
 
 - Fixed dependencies screwed up in v1.52
+- Fixed issue #18 where tests failed due updates to the V&A site.
 
 1.52      2017-02-27 10:21:36-06:00 America/Chicago
 

--- a/t/passthrough.t
+++ b/t/passthrough.t
@@ -13,7 +13,7 @@ my $TEST_FILE_DIR = qq{$Bin/files};
 my $vanilla_ua = Mojo::UserAgent->new();
 
 subtest 'Victoria and Albert Museum' => sub {
-    my $url = Mojo::URL->new(q{http://www.vam.ac.uk/api/json/museumobject/O1}); 
+    my $url = Mojo::URL->new(q{https://www.vam.ac.uk/api/json/museumobject/O1});
     my $result = Mojo::UserAgent->new->get($url)->res->json;
 
     plan skip_all => 'Museum API not responding properly' unless ref $result eq 'ARRAY' && $result->[0]{'pk'};

--- a/t/passthrough_nonblocking.t
+++ b/t/passthrough_nonblocking.t
@@ -10,7 +10,7 @@ use Time::HiRes qw/tv_interval gettimeofday/;
 my $TEST_FILE_DIR = qq{$Bin/files};
 my $vanilla_ua    = Mojo::UserAgent->new();
 
-my $url    = Mojo::URL->new(q{http://www.vam.ac.uk/api/json/museumobject/O1});
+my $url    = Mojo::URL->new(q{https://www.vam.ac.uk/api/json/museumobject/O1});
 my $result = Mojo::UserAgent->new->get($url)->res->json;
 
 plan skip_all => 'Museum API not responding properly' unless ref $result eq 'ARRAY' && $result->[0]{'pk'};

--- a/t/record.t
+++ b/t/record.t
@@ -13,7 +13,7 @@ push @transactions, Mojo::UserAgent->new->get(q{https://www.vam.ac.uk/api/json/m
 
 my @results = map { $_->res->json } @transactions;
 
-BAIL_OUT('Museum API not responding properly') unless $results[0]->[0]->{'pk'};
+plan skip_all => 'Museum API not responding properly' unless $results[0]->[0]->{'pk'};
 
 my $output_file = qq{$dir/victoria_and_albert.json};
 

--- a/t/record.t
+++ b/t/record.t
@@ -9,7 +9,7 @@ use Test::Most;
 my $dir = File::Temp->newdir;
 
 my @transactions;
-push @transactions, Mojo::UserAgent->new->get(q{http://www.vam.ac.uk/api/json/museumobject/O1}), Mojo::UserAgent->new->get(q{http://www.vam.ac.uk/api/json/museumobject/O1}); 
+push @transactions, Mojo::UserAgent->new->get(q{https://www.vam.ac.uk/api/json/museumobject/O1}), Mojo::UserAgent->new->get(q{https://www.vam.ac.uk/api/json/museumobject/O1}); 
 
 my @results = map { $_->res->json } @transactions;
 
@@ -31,4 +31,3 @@ my @deserialized = Mojo::UserAgent::Mockable::Serializer->new->retrieve($output_
 
 is scalar @deserialized, scalar @transactions, 'Transaction count matches';
 done_testing;
-

--- a/t/record_nonblocking.t
+++ b/t/record_nonblocking.t
@@ -9,7 +9,7 @@ use Test::Most;
 my $dir = File::Temp->newdir;
 
 my @transactions;
-push @transactions, Mojo::UserAgent->new->get(q{http://www.vam.ac.uk/api/json/museumobject/O1}), Mojo::UserAgent->new->get(q{http://www.vam.ac.uk/api/json/museumobject/O1}); 
+push @transactions, Mojo::UserAgent->new->get(q{https://www.vam.ac.uk/api/json/museumobject/O1}), Mojo::UserAgent->new->get(q{https://www.vam.ac.uk/api/json/museumobject/O1}); 
 
 my @results = map { $_->res->json } @transactions;
 

--- a/t/record_playback.t
+++ b/t/record_playback.t
@@ -105,7 +105,7 @@ for my $cookie (@{$mock->cookie_jar->all}) {
     my $name = $cookie->name;
     my $original_cookie = $cookies{$domain}{$name};
     subtest qq{Cookie "$name"} => sub {
-        for my $attr (qw/domain expires httponly max_age origin path secure/) {
+        for my $attr (qw/domain expires httponly max_age path secure/) {
             is $cookie->$attr, $original_cookie->$attr, qq{"$attr" matches};
         }
     };

--- a/t/serializer/simple.t
+++ b/t/serializer/simple.t
@@ -16,7 +16,7 @@ subtest 'Victoria and Albert Museum' => sub {
     my $dir = File::Temp->newdir;
    
     my @transactions;
-    push @transactions, Mojo::UserAgent->new->get(q{http://www.vam.ac.uk/api/json/museumobject/?limit=1});
+    push @transactions, Mojo::UserAgent->new->get(q{https://www.vam.ac.uk/api/json/museumobject/?limit=1});
 
     my $result = $transactions[0]->res->json;
 
@@ -25,7 +25,7 @@ subtest 'Victoria and Albert Museum' => sub {
 
     my $object_number = $result->{'records'}[0]{'fields'}{'object_number'};
 
-    push @transactions, Mojo::UserAgent->new->get(qq{http://www.vam.ac.uk/api/json/museumobject/$object_number}); 
+    push @transactions, Mojo::UserAgent->new->get(qq{https://www.vam.ac.uk/api/json/museumobject/$object_number}); 
     my $museum_object = $transactions[1]->res->json;
 
     plan skip_all => 'Museum object not retrieved properly' unless @{$museum_object} && keys %{$museum_object->[0]};

--- a/t/serializer/store_retrieve.t
+++ b/t/serializer/store_retrieve.t
@@ -20,7 +20,7 @@ subtest 'Victoria and Albert Museum' => sub {
     my $output_file = qq{$dir/victoria_and_albert.json};
 
     my @transactions;
-    push @transactions, Mojo::UserAgent->new->get(q{http://www.vam.ac.uk/api/json/museumobject/?limit=1});
+    push @transactions, Mojo::UserAgent->new->get(q{https://www.vam.ac.uk/api/json/museumobject/?limit=1});
 
     my $result = $transactions[0]->res->json;
 
@@ -29,7 +29,7 @@ subtest 'Victoria and Albert Museum' => sub {
 
     my $object_number = $result->{'records'}[0]{'fields'}{'object_number'};
 
-    push @transactions, Mojo::UserAgent->new->get(qq{http://www.vam.ac.uk/api/json/museumobject/$object_number}); 
+    push @transactions, Mojo::UserAgent->new->get(qq{https://www.vam.ac.uk/api/json/museumobject/$object_number});
     my $museum_object = $transactions[1]->res->json;
 
     plan skip_all => 'Museum object not retrieved properly' unless @{$museum_object} && keys %{$museum_object->[0]};


### PR DESCRIPTION
#18 Fixes the Issue highlighted here

- A 302 redirect is now in place on the V&A site to https.  I updated these test URLs.
- Updated the 'record' test to skip if this happens again where it is not available.
- Removes 'origin' from the expected attributes for Mojo::Cookie::Response (this was removed in Mojo v7.66).