### PR TITLE
Ability to compare a url containing a list of the same params

### DIFF
--- a/lib/Mojo/UserAgent/Mockable/Request/Compare.pm
+++ b/lib/Mojo/UserAgent/Mockable/Request/Compare.pm
@@ -139,8 +139,16 @@ sub _compare_url {
         return 0;
     }
     for my $key (keys %{$q1}) {
-        if ($q1->{$key} ne $q2->{$key}) {
-            $self->compare_result(qq{URL query mismatch: for key "$key", got "$q1->{$key}", expected "$q2->{$key}"});
+        my $val1 = $q1->{$key};
+        my $val2 = $q2->{$key};
+
+        if ( ref $val2 eq 'ARRAY' ){
+            $val1 = join(",", sort { $a cmp $b } @{$val1});
+            $val2 = join(",", sort { $a cmp $b } @{$val2});
+        }
+
+        if ($val1 ne $val2) {
+            $self->compare_result(qq{URL query mismatch: for key "$key", got "$val1", expected "$val2"});
             return 0;
         }
     }

--- a/t/request_compare/url.t
+++ b/t/request_compare/url.t
@@ -36,6 +36,17 @@ subtest 'Equivalent URL, different query order' => sub {
     is $compare->compare_result, '', 'Compare result is empty';
 };
 
+subtest 'Equivalent URL, different order of values for list param' => sub {
+    my $compare = Mojo::UserAgent::Mockable::Request::Compare->new;
+    my $r2 = $r1->clone;
+    my $r3 = $r1->clone;
+
+    $r2->url->query->append(foo => ['baz','boo']);
+    $r3->url->query->append(foo => ['boo','baz']);
+    ok $compare->compare( $r2, $r3 ), 'Equivalent requests are equivalent';
+    is $compare->compare_result, '', 'Compare result is empty';
+};
+
 subtest 'Different query' => sub {
     my $compare = Mojo::UserAgent::Mockable::Request::Compare->new;
     my $r2 = $r1->clone;


### PR DESCRIPTION
Hey Kit!

Currently, this will break if you provide it with the following url:
`http://www.example.com/index.html?foo=baz&foo=boo&foo=bar`

Now, I'm not entirely sure if the ordering is required in the comparison. You might want to preserve the original and say these requests are not equal, but it would be nice to be able compare such requests.