### PR TITLE
#32 - better random.org quota handling

### DIFF
--- a/t/lib/RandomOrgQuota.pm
+++ b/t/lib/RandomOrgQuota.pm
@@ -12,7 +12,7 @@ sub check_quota {
         $quota = get_quota();
         1;
     } or die qq{Failed to get quota: $@\n};
-    return $quota >= $minimum;
+    return $quota && $quota >= $minimum;
 }
 
 sub get_quota {
@@ -23,8 +23,11 @@ sub get_quota {
     my $quota;
     eval {
         my $res = $tx->result;
-        if ( $res->code eq 200 ) {
+        if ( $res->code == 200 ) {
             $quota = int $res->body;
+        }
+        elsif ($res->code == 403) {
+            $quota = 0;
         }
         else { die qq{$res->{code} $res->{message}\n}; }
         1;

--- a/t/mojo_url.t
+++ b/t/mojo_url.t
@@ -43,6 +43,8 @@ my $original_port   = $url->port;
 my $output_file = qq{$dir/output.json};
 
 my $transaction_count = 3;
+plan skip_all => 'Random.org quota exceeded' unless check_quota($transaction_count);
+
 # Record the interchange
 my ( @results, @transactions );
 {    # Look! Scoping braces!
@@ -50,7 +52,6 @@ my ( @results, @transactions );
     $mock->transactor->name('kit.peters@broadbean.com');
 
     for ( 1 .. $transaction_count ) {
-        plan skip_all => 'Random.org quota exceeded' unless check_quota();
         push @transactions, $mock->get( $url->clone->query( [ quux => int rand 1e9 ] ));
     }
 

--- a/t/record_playback.t
+++ b/t/record_playback.t
@@ -42,6 +42,8 @@ my $app = $args{'app'};
 my $output_file = qq{$dir/output.json};
 
 my $transaction_count = 10;
+plan skip_all => 'Random.org quota exceeded' unless check_quota($transaction_count);
+
 my %cookies;
 my $cookie_count = 0;
 # Record the interchange
@@ -51,7 +53,6 @@ my ( @results, @transactions );
     $mock->transactor->name('kit.peters@broadbean.com');
 
     for ( 1 .. $transaction_count ) {
-        plan skip_all => 'Random.org quota exceeded' unless check_quota();
         push @transactions, $mock->get( $url->clone->query( [ quux => int rand 1e9 ] ));
     }
 

--- a/t/record_playback_nonblocking.t
+++ b/t/record_playback_nonblocking.t
@@ -40,6 +40,8 @@ my $url = Mojo::URL->new(q{https://www.random.org/integers/})->query(
 my $output_file = qq{$dir/output.json};
 
 my $transaction_count = 10;
+plan skip_all => 'Random.org quota exceeded' unless check_quota($transaction_count);
+
 # Record the interchange
 my ( @results, @transactions );
 {    # Look! Scoping braces!
@@ -47,7 +49,6 @@ my ( @results, @transactions );
     $mock->transactor->name('kit.peters@broadbean.com');
 
     for (1 .. $transaction_count) {
-        plan skip_all => 'Random.org quota exceeded' unless check_quota();
         $mock->get(
             $url->clone->query( [ quux => int rand 1e9 ] ),
             sub {

--- a/t/record_playback_normalized.t
+++ b/t/record_playback_normalized.t
@@ -37,6 +37,7 @@ my $url = Mojo::URL->new(q{https://www.random.org/integers/})->query(
 );
 my $output_file = qq{$dir/output_normalized.json};
 my $transaction_count = 10;
+plan skip_all => 'Random.org quota exceeded' unless check_quota($transaction_count);
 
 note "Record the interchange";
 my ( @results, @transactions );
@@ -45,7 +46,6 @@ my ( @results, @transactions );
     $mock->transactor->name('kit.peters@broadbean.com');
 
     for ( 1 .. $transaction_count ) {
-        plan skip_all => 'Random.org quota exceeded' unless check_quota();
         push @transactions, $mock->get( $url->clone->query( [ quux => int rand 1e9 ] ));
     }
     @results = map { [ split /\n/, $_->res->text ] } @transactions;


### PR DESCRIPTION
This PR:

* ensures `check_quota()` doesn't return true when quota is zero (minimum was never being set)
* moves the calls to `check_quota()` out of the loops so they only happen once per test script
* calls to `check_quota()` include the minimum required for that test script

thanks!
Michael