### PR TITLE
The `sort_by` option used in c6b5d1c is not present in (some versions of?) JSON::XS. `canonical` is more portable.

### DIFF
--- a/lib/Mojo/UserAgent/Mockable/Serializer.pm
+++ b/lib/Mojo/UserAgent/Mockable/Serializer.pm
@@ -178,7 +178,7 @@ sub serialize {
     for (0 .. $#serialized) {
         $serialized[$_]->{txn_num} = $_;
     }
-    my $JSON = JSON::MaybeXS->new(pretty => 1, sort_by => 1, utf8 => 1);
+    my $JSON = JSON::MaybeXS->new(pretty => 1, canonical => 1, utf8 => 1);
     return $JSON->encode( \@serialized );
 }
 

--- a/t/canonicalize_portably_Cpanel-JSON-XS.t
+++ b/t/canonicalize_portably_Cpanel-JSON-XS.t
@@ -1,0 +1,11 @@
+# Force JSON::MaybeXS to only use this one particular JSON-ish module.
+# We don't hide JSON::PP because Mojo::JSON loads it explicitly, but
+# JSON::MaybeXS (used by Mojo::UserAgent::Mockable) should pick one of
+# the XS options first.
+use Devel::Hide qw(JSON::XS);
+use Test::More;
+
+eval 'use Cpanel::JSON::XS';
+plan skip_all => 'Cpanel::JSON::XS required for this test' if($@);
+
+require './t/record_playback.t';

--- a/t/canonicalize_portably_JSON-PP.t
+++ b/t/canonicalize_portably_JSON-PP.t
@@ -1,0 +1,9 @@
+# Force JSON::MaybeXS to only use this one particular JSON-ish module.
+use Devel::Hide qw(Cpanel::JSON::XS JSON::XS);
+use Test::More;
+
+eval 'use JSON::PP';
+plan skip_all => 'JSON::PP required for this test' if($@);
+
+require './t/record_playback.t';
+

--- a/t/canonicalize_portably_JSON-XS.t
+++ b/t/canonicalize_portably_JSON-XS.t
@@ -1,0 +1,12 @@
+# Force JSON::MaybeXS to only use this one particular JSON-ish module.
+# We don't hide JSON::PP because Mojo::JSON loads it explicitly, but
+# JSON::MaybeXS (used by Mojo::UserAgent::Mockable) should pick one of
+# the XS options first.
+use Devel::Hide qw(Cpanel::JSON::XS);
+use Test::More;
+
+eval 'use JSON::XS';
+plan skip_all => 'JSON::XS required for this test' if($@);
+
+require './t/record_playback.t';
+

--- a/t/record_playback.t
+++ b/t/record_playback.t
@@ -1,3 +1,5 @@
+# NB this test is also run from t/canonicalize_portably_*
+
 use 5.014;
 
 use File::Temp;


### PR DESCRIPTION
The new test files use Devel::Hide to force JSON::MaybeXS to use particular
JSON-ish modules, and will skip if the module in question is not available.
To get full test coverage of all the possibilities you'll need to have all
of JSON::PP, JSON::XS, and Cpanel::JSON::XS installed, which I recommend in
dev and CI. Ordinary users won't need to care though, provided that they've
got one of them installed everything should Just Work (tm).