### PR TITLE
Fix POD

### DIFF
--- a/lib/Mojo/UserAgent/Mockable.pm
+++ b/lib/Mojo/UserAgent/Mockable.pm
@@ -279,8 +279,11 @@ You can also do the following (as seen in t/030_basic_authentication.t):
 The following transaction level events will not be emitted during playback:
 
 =for :list
+
 =item pre_freeze
+
 =item post_freeze
+
 =item resume
 
 =method save
@@ -290,8 +293,10 @@ In record mode, save the transaction cache to the file specified by L</file> for
 =head1 SEE ALSO
 
 =for :list
+
 =item * L<Mojo::UserAgent> 
 The class being mocked (but not derided, because the whole Mojo thing is really quite clever)
+
 =item * L<Mojo::Transaction::HTTP> 
 Where the magic happens
 


### PR DESCRIPTION
These don't render properly and show up as `pre_freeze =item post_freeze...` on metacpan.